### PR TITLE
chore: update dependencies & gradle / add usePathStyle option

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
       - name: Validate
         run: ./gradlew check validatePlugins --continue
       - name: Integration Test

--- a/.github/workflows/publish-plugin.yaml
+++ b/.github/workflows/publish-plugin.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
       - name: Validate
         run: ./gradlew check validatePlugins --continue
       - name: Integration Test

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The `uploadPackage` task comes equipped with a range of both required and option
 - **signingKeyPassphrase**: *(Required)* The passphrase for the PGP private key.
 - **bucketPath**: *(Optional)* The path within the bucket to store the Apt Repository. If not specified, the repository is stored at the root of the bucket.
 - **endpoint**: *(Optional)* Custom S3 endpoint. Use this to override the default AWS S3 endpoint.
+- **usePathStyle**: *(Optional)* Boolean value indicating whether to use path-style access for S3 bucket operations. Default is false. Set to true when using S3-compatible storage systems like MinIO, or in specific scenarios with actual S3 where path-style access is required.
 - **override**: *(Optional)* Boolean value indicating whether to override existing version of a Package. By default, it is `true`.
  
 `Release File Attributes` can be override in s3AptRepository or per debPackage
@@ -73,7 +74,7 @@ In the `debPackage` section, you can specify package-specific attributes. These 
 - **packageArchitectures**: *(Required)* Set of architectures that the package supports.
 - **packageName**, **packageVersion**: *(Optional)* These attributes can be used to override the default package name and version extracted form the Debian File.
 - **origin**, **label**, **suite**, **component**, **architectures**, **codename**, **date**, **releaseDescription**, **releaseVersion**, **validUntil**, **notAutomatic**, **butAutomaticUpgrades**, **changelogs**, **snapshots** : *(Optional)* These attributes can be used to override the default Release file fields for the specific package.
-- **accessKey**, **secretKey**, **bucket**, **bucketPath**, **region**, **endpoint**: *(Optional)* These attributes can be used to override their respective top-level attributes for the specific package.
+- **accessKey**, **secretKey**, **bucket**, **bucketPath**, **region**, **endpoint**, **usePathStyle**: *(Optional)* These attributes can be used to override their respective top-level attributes for the specific package.
 
 
 
@@ -91,6 +92,7 @@ The `removePackage` task comes equipped with a range of both required and option
 - **signingKeyPassphrase**: *(Required)* The passphrase for the PGP private key.
 - **bucketPath**: *(Optional)* The path within the bucket to store the Apt Repository. If not specified, the repository is stored at the root of the bucket.
 - **endpoint**: *(Optional)* Custom S3 endpoint. Use this to override the default AWS S3 endpoint.
+- **usePathStyle**: *(Optional)* Boolean value indicating whether to use path-style access for S3 bucket operations. Default is false. Set to true when using S3-compatible storage systems like MinIO, or in specific scenarios with actual S3 where path-style access is required.
 - **origin**: *(Optional)* The value of the 'Origin' field in the Release files. By default, it is 'Debian'.
 
 `Release File Attributes` can be override in s3AptRepository or per debPackage
@@ -117,7 +119,7 @@ In the `debPackage` section, you can specify package-specific attributes. These 
 - **packageArchitectures**: *(Required)* Set of architectures that the package supports.
 - **packageName**, **packageVersion**: *(Optional)* These attributes can be used to override the default package name and version extracted form the Debian File.
 - **origin**, **label**, **suite**, **component**, **architectures**, **codename**, **date**, **releaseDescription**, **releaseVersion**, **validUntil**, **notAutomatic**, **butAutomaticUpgrades**, **changelogs**, **snapshots** : *(Optional)* These attributes can be used to override the default Release file fields for the specific package.
-- **accessKey**, **secretKey**, **bucket**, **bucketPath**, **region**, **endpoint**: *(Optional)* These attributes can be used to override their respective top-level attributes for the specific package.
+- **accessKey**, **secretKey**, **bucket**, **bucketPath**, **region**, **endpoint**, **usePathStyle**: *(Optional)* These attributes can be used to override their respective top-level attributes for the specific package.
 
 
 ### cleanPackages
@@ -130,6 +132,7 @@ The `cleanPackages` task comes equipped with a range of both required and option
 - **secretKey**: *(Required)* The AWS Secret Key for accessing the S3 bucket. Can be overridden in the `debPackage` section.
 - **bucketPath**: *(Optional)* The path within the bucket to store the Apt Repository. If not specified, the repository is stored at the root of the bucket.
 - **endpoint**: *(Optional)* Custom S3 endpoint. Use this to override the default AWS S3 endpoint.
+- **usePathStyle**: *(Optional)* Boolean value indicating whether to use path-style access for S3 bucket operations. Default is false. Set to true when using S3-compatible storage systems like MinIO, or in specific scenarios with actual S3 where path-style access is required.
 - **suite**: *(Optional)* The value of the 'Suite' field in the Release files. By default, it is 'stable'.
 - **component**: *(Optional)* The value of the 'Component' field in the Release files. By default, it is 'main'.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,20 +55,16 @@ tasks {
 gradlePlugin {
     val integrationMain by sourceSets
     testSourceSets(integrationMain)
+    website.set("https://github.com/Liftric/s3-apt-repository-plugin")
+    vcsUrl.set("https://github.com/Liftric/s3-apt-repository-plugin")
     plugins {
         create("s3-apt-repository-plugin") {
             id = "$group.s3-apt-repository-plugin"
             implementationClass = "$group.apt.S3AptRepositoryPlugin"
             displayName = "s3-apt-repository-plugin"
+            tags.set(listOf("s3", "apt", "repository", "debian"))
         }
     }
-}
-
-pluginBundle {
-    website = "https://github.com/Liftric/s3-apt-repository-plugin"
-    vcsUrl = "https://github.com/Liftric/s3-apt-repository-plugin"
-    description = "A Gradle Plugin for managing an APT Repository on S3"
-    tags = listOf("s3", "apt", "repository", "debian")
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,31 +4,30 @@ pluginManagement {
     dependencyResolutionManagement {
         versionCatalogs {
             create("libs") {
-                version("kotlin", "1.8.21")
-                version("ktor", "2.3.0")
-                version("junit", "5.9.3")
-                version("awsSdk", "2.17.125")
-                version("bouncycastle", "1.70")
-                version("testContainers", "1.18.3")
+                version("kotlin", "1.9.25")
+                version("junit", "5.10.3")
+                version("awsSdk", "2.27.0")
+                version("bouncycastle", "1.78.1")
+                version("testContainers", "1.20.1")
 
-                plugin("dockerCompose", "com.avast.gradle.docker-compose").version("0.16.12")
+                plugin("dockerCompose", "com.avast.gradle.docker-compose").version("0.17.7")
                 plugin("kotlinJvm", "org.jetbrains.kotlin.jvm").versionRef("kotlin")
                 plugin("kotlinSerialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
-                plugin("gradlePluginPublish", "com.gradle.plugin-publish").version("1.2.0")
-                plugin("nemerosaVersioning", "net.nemerosa.versioning").version("3.0.0")
+                plugin("gradlePluginPublish", "com.gradle.plugin-publish").version("1.2.1")
+                plugin("nemerosaVersioning", "net.nemerosa.versioning").version("3.1.0")
 
                 library("kotlinStdlibJdk8", "org.jetbrains.kotlin", "kotlin-stdlib-jdk8").versionRef("kotlin")
                 library("junitBom", "org.junit", "junit-bom").versionRef("junit")
                 library("junitJupiter", "org.junit.jupiter", "junit-jupiter").versionRef("junit")
                 library("awsS3", "software.amazon.awssdk", "s3").versionRef("awsSdk")
-                library("bouncyCastleGPG", "org.bouncycastle", "bcpg-jdk15on").versionRef("bouncycastle")
-                library("bouncyCastleProvider", "org.bouncycastle", "bcprov-jdk15on").versionRef("bouncycastle")
-                library("xz", "org.tukaani", "xz").version("1.9")
-                library("apacheCommons", "org.apache.commons", "commons-compress").version("1.12")
+                library("bouncyCastleGPG", "org.bouncycastle", "bcpg-jdk18on").versionRef("bouncycastle")
+                library("bouncyCastleProvider", "org.bouncycastle", "bcprov-jdk18on").versionRef("bouncycastle")
+                library("xz", "org.tukaani", "xz").version("1.10")
+                library("apacheCommons", "org.apache.commons", "commons-compress").version("1.27.0")
                 library("testContainersJUnit5", "org.testcontainers", "junit-jupiter").versionRef("testContainers")
                 library("testContainersMain", "org.testcontainers", "testcontainers").versionRef("testContainers")
-                library("minio", "io.minio", "minio").version("8.5.3")
-                library("mockk", "io.mockk", "mockk").version("1.13.5")
+                library("minio", "io.minio", "minio").version("8.5.11")
+                library("mockk", "io.mockk", "mockk").version("1.13.12")
             }
         }
     }

--- a/src/integrationMain/kotlin/com/liftric/apt/CleanPackagesTest.kt
+++ b/src/integrationMain/kotlin/com/liftric/apt/CleanPackagesTest.kt
@@ -74,7 +74,7 @@ import com.netflix.gradle.plugins.deb.Deb
 
 plugins {
     id("com.liftric.s3-apt-repository-plugin")
-    id("com.netflix.nebula.ospackage") version "11.3.0"
+    id("com.netflix.nebula.ospackage") version "11.9.1"
 }
 
 group = "com.liftric.test"
@@ -84,6 +84,7 @@ s3AptRepository {
     bucket.set("$CLEAN_PACKAGES_TEST_BUCKET")
     region.set("eu-central-1")
     endpoint.set("http://localhost:${MINIO_CONTAINER.getMappedPort(MINIO_PORT)}")
+    usePathStyle.set(true)
     accessKey.set("$MINIO_ACCESS_KEY")
     secretKey.set("$MINIO_SECRET_KEY")
 }

--- a/src/integrationMain/kotlin/com/liftric/apt/ContainerBase.kt
+++ b/src/integrationMain/kotlin/com/liftric/apt/ContainerBase.kt
@@ -30,7 +30,7 @@ abstract class ContainerBase {
         val network: Network = Network.newNetwork()
 
         val MINIO_CONTAINER: GenericContainer<*> =
-            GenericContainer(DockerImageName.parse("quay.io/minio/minio:RELEASE.2023-06-02T23-17-26Z"))
+            GenericContainer(DockerImageName.parse("quay.io/minio/minio:RELEASE.2024-08-03T04-33-23Z"))
                 .withPrivilegedMode(true)
                 .withNetwork(network)
                 .withNetworkAliases("minio")

--- a/src/integrationMain/kotlin/com/liftric/apt/RemovePackageTest.kt
+++ b/src/integrationMain/kotlin/com/liftric/apt/RemovePackageTest.kt
@@ -74,7 +74,7 @@ import com.netflix.gradle.plugins.deb.Deb
 
 plugins {
     id("com.liftric.s3-apt-repository-plugin")
-    id("com.netflix.nebula.ospackage") version "11.3.0"
+    id("com.netflix.nebula.ospackage") version "11.9.1"
 }
 
 group = "com.liftric.test"
@@ -103,6 +103,7 @@ s3AptRepository {
     bucket.set("$REMOVE_PACKAGE_TEST_BUCKET")
     region.set("eu-central-1")
     endpoint.set("http://localhost:${MINIO_CONTAINER.getMappedPort(MINIO_PORT)}")
+    usePathStyle.set(true)
     accessKey.set("$MINIO_ACCESS_KEY")
     secretKey.set("$MINIO_SECRET_KEY")
     signingKeyPassphrase.set("$SIGNING_KEY_PASSPHRASE")

--- a/src/integrationMain/kotlin/com/liftric/apt/UploadPackageTest.kt
+++ b/src/integrationMain/kotlin/com/liftric/apt/UploadPackageTest.kt
@@ -71,7 +71,7 @@ import com.netflix.gradle.plugins.deb.Deb
 
 plugins {
     id("com.liftric.s3-apt-repository-plugin")
-    id("com.netflix.nebula.ospackage") version "11.3.0"
+    id("com.netflix.nebula.ospackage") version "11.9.1"
 }
 
 group = "com.liftric.test"
@@ -100,6 +100,7 @@ s3AptRepository {
     bucket.set("$UPLOAD_PACKAGE_TEST_BUCKET")
     region.set("eu-central-1")
     endpoint.set("http://localhost:${MINIO_CONTAINER.getMappedPort(MINIO_PORT)}")
+    usePathStyle.set(true)
     accessKey.set("$MINIO_ACCESS_KEY")
     secretKey.set("$MINIO_SECRET_KEY")
     signingKeyPassphrase.set("$SIGNING_KEY_PASSPHRASE")

--- a/src/integrationMain/kotlin/com/liftric/apt/UploadPackageTest2.kt
+++ b/src/integrationMain/kotlin/com/liftric/apt/UploadPackageTest2.kt
@@ -59,7 +59,7 @@ import com.netflix.gradle.plugins.deb.Deb
 
 plugins {
     id("com.liftric.s3-apt-repository-plugin")
-    id("com.netflix.nebula.ospackage") version "11.3.0"
+    id("com.netflix.nebula.ospackage") version "11.9.1"
 }
 
 group = "com.liftric.test"
@@ -88,6 +88,7 @@ s3AptRepository {
     bucket.set("$UPLOAD_PACKAGE_TEST_BUCKET_2")
     region.set("eu-central-1")
     endpoint.set("http://localhost:${MINIO_CONTAINER.getMappedPort(MINIO_PORT)}")
+    usePathStyle.set(true)
     accessKey.set("$MINIO_ACCESS_KEY")
     secretKey.set("$MINIO_SECRET_KEY")
     signingKeyPassphrase.set("$SIGNING_KEY_PASSPHRASE")

--- a/src/main/kotlin/com/liftric/apt/S3AptRepositoryPlugin.kt
+++ b/src/main/kotlin/com/liftric/apt/S3AptRepositoryPlugin.kt
@@ -34,6 +34,7 @@ class S3AptRepositoryPlugin : Plugin<Project> {
             task.bucketPath.set(extension.bucketPath.convention(""))
             task.region.set(extension.region)
             task.endpoint.set(extension.endpoint)
+            task.usePathStyle.set(extension.usePathStyle)
             task.override.set(extension.override)
             task.debianFiles.set(extension.debPackages)
             task.signingKeyRingFile.set(extension.signingKeyRingFile)
@@ -63,6 +64,7 @@ class S3AptRepositoryPlugin : Plugin<Project> {
             task.bucketPath.set(extension.bucketPath.convention(""))
             task.region.set(extension.region)
             task.endpoint.set(extension.endpoint)
+            task.usePathStyle.set(extension.usePathStyle)
             task.debianFiles.set(extension.debPackages)
             task.signingKeyRingFile.set(extension.signingKeyRingFile)
             task.signingKeyPassphrase.set(extension.signingKeyPassphrase)
@@ -91,6 +93,7 @@ class S3AptRepositoryPlugin : Plugin<Project> {
             task.bucketPath.set(extension.bucketPath.convention(""))
             task.region.set(extension.region)
             task.endpoint.set(extension.endpoint)
+            task.usePathStyle.set(extension.usePathStyle)
             task.suite.set(extension.suite.convention(DEFAULT_SUITE))
             task.components.set(extension.components.convention(DEFAULT_COMPONENT))
         }

--- a/src/main/kotlin/com/liftric/apt/extensions/DebPackage.kt
+++ b/src/main/kotlin/com/liftric/apt/extensions/DebPackage.kt
@@ -39,7 +39,7 @@ class DebPackage(@get:Internal val project: Project) {
 
     @get:Input
     @get:Optional
-    // Used for override the default S3 endpoint
+    // Used to force s3 path style access 
     val usePathStyle: Property<Boolean?> = project.objects.property(Boolean::class.java)
 
     @get:Input

--- a/src/main/kotlin/com/liftric/apt/extensions/DebPackage.kt
+++ b/src/main/kotlin/com/liftric/apt/extensions/DebPackage.kt
@@ -7,12 +7,13 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFile
 
 @Suppress("MemberVisibilityCanBePrivate")
 @ConfigDsl
 class DebPackage(@get:Internal val project: Project) {
 
-    @get:Input
+    @get:InputFile
     // The Package file to upload. Currently only Debian Files are supported */
     val file: RegularFileProperty = project.objects.fileProperty()
 

--- a/src/main/kotlin/com/liftric/apt/extensions/DebPackage.kt
+++ b/src/main/kotlin/com/liftric/apt/extensions/DebPackage.kt
@@ -39,6 +39,11 @@ class DebPackage(@get:Internal val project: Project) {
 
     @get:Input
     @get:Optional
+    // Used for override the default S3 endpoint
+    val usePathStyle: Property<Boolean?> = project.objects.property(Boolean::class.java)
+
+    @get:Input
+    @get:Optional
     // Optional: Used for override the default accessKey
     val accessKey: Property<String?> = project.objects.property(String::class.java)
 

--- a/src/main/kotlin/com/liftric/apt/extensions/extension.kt
+++ b/src/main/kotlin/com/liftric/apt/extensions/extension.kt
@@ -17,6 +17,7 @@ abstract class S3AptRepositoryPluginExtension(val project: Project) {
     abstract val bucketPath: Property<String>
     abstract val region: Property<String>
     abstract val endpoint: Property<String>
+    abstract val usePathStyle: Property<Boolean>
 
     /** Override Versions that already exist in Apt Repository, Default is true */
     abstract val override: Property<Boolean>

--- a/src/main/kotlin/com/liftric/apt/service/AwsS3Client.kt
+++ b/src/main/kotlin/com/liftric/apt/service/AwsS3Client.kt
@@ -30,7 +30,8 @@ class AwsS3Client(
     accessKey: String,
     secretKey: String,
     region: String,
-    endpoint: String? = null,
+    endpoint: String?,
+    usePathStyle: Boolean,
 ) {
     private val s3Client by lazy {
         with(S3Client.builder()) {
@@ -39,6 +40,7 @@ class AwsS3Client(
                     endpointOverride(URI.create(endpoint))
                 }
             }
+            forcePathStyle(usePathStyle)
             region(convertToRegion(region))
             credentialsProvider(
                 StaticCredentialsProvider.create(

--- a/src/main/kotlin/com/liftric/apt/tasks/CleanPackages.kt
+++ b/src/main/kotlin/com/liftric/apt/tasks/CleanPackages.kt
@@ -36,6 +36,10 @@ abstract class CleanPackages : DefaultTask() {
     @get:Optional
     abstract val endpoint: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val usePathStyle: Property<Boolean>
+
     @TaskAction
     fun main() {
         val suiteValue = suite.get()
@@ -46,8 +50,9 @@ abstract class CleanPackages : DefaultTask() {
         val bucketPathValue = bucketPath.get()
         val regionValue = region.get()
         val endpointValue = endpoint.orNull
+        val usePathStyleValue = usePathStyle.getOrElse(false)
 
-        val s3Client = AwsS3Client(accessKeyValue, secretKeyValue, regionValue, endpointValue)
+        val s3Client = AwsS3Client(accessKeyValue, secretKeyValue, regionValue, endpointValue, usePathStyleValue)
 
         val usedPackages = getUsedPackagesPoolKeys(s3Client, bucketValue, bucketPathValue, suiteValue, componentValue)
         cleanPackages(logger, s3Client, bucketValue, bucketPathValue, componentValue, usedPackages)

--- a/src/main/kotlin/com/liftric/apt/tasks/RemovePackage.kt
+++ b/src/main/kotlin/com/liftric/apt/tasks/RemovePackage.kt
@@ -38,7 +38,7 @@ abstract class RemovePackage : DefaultTask() {
     @get:Optional
     abstract val endpoint: Property<String>
 
-    @get:Input
+    @get:InputFile
     @get:Optional
     abstract val signingKeyRingFile: RegularFileProperty
 

--- a/src/main/kotlin/com/liftric/apt/tasks/RemovePackage.kt
+++ b/src/main/kotlin/com/liftric/apt/tasks/RemovePackage.kt
@@ -38,6 +38,10 @@ abstract class RemovePackage : DefaultTask() {
     @get:Optional
     abstract val endpoint: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val usePathStyle: Property<Boolean>
+
     @get:InputFile
     @get:Optional
     abstract val signingKeyRingFile: RegularFileProperty
@@ -124,6 +128,7 @@ abstract class RemovePackage : DefaultTask() {
             val bucketPath = debianFile.bucketPath.orNull ?: bucketPath.get()
             val region = debianFile.region.orNull ?: region.get()
             val endpoint = debianFile.endpoint.orNull ?: endpoint.orNull
+            val usePathStyle = debianFile.usePathStyle.orNull ?: usePathStyle.orNull ?: false
 
             /** Release file values **/
             val origin = debianFile.origin.orNull ?: origin.get()
@@ -141,7 +146,7 @@ abstract class RemovePackage : DefaultTask() {
             val changelogs = debianFile.changelogs.orNull ?: changelogs.orNull
             val snapshots = debianFile.snapshots.orNull ?: snapshots.orNull
 
-            val s3Client = AwsS3Client(accessKey, secretKey, region, endpoint)
+            val s3Client = AwsS3Client(accessKey, secretKey, region, endpoint, usePathStyle)
             val debianPackages =
                 PackagesFactory.parseDebianFile(inputFile, archs, "", packageName, packageVersion)
 

--- a/src/main/kotlin/com/liftric/apt/tasks/UploadPackage.kt
+++ b/src/main/kotlin/com/liftric/apt/tasks/UploadPackage.kt
@@ -40,6 +40,10 @@ abstract class UploadPackage : DefaultTask() {
 
     @get:Input
     @get:Optional
+    abstract val usePathStyle: Property<Boolean>
+
+    @get:Input
+    @get:Optional
     abstract val override: Property<Boolean>
 
     @get:InputFile
@@ -126,6 +130,7 @@ abstract class UploadPackage : DefaultTask() {
             val secretKey = debianFile.secretKey.orNull ?: secretKey.get()
             val region = debianFile.region.orNull ?: region.get()
             val endpoint = debianFile.endpoint.orNull ?: endpoint.orNull
+            val usePathStyle = debianFile.usePathStyle.orNull ?: usePathStyle.orNull ?: false
             val bucket = debianFile.bucket.orNull ?: bucket.get()
             val bucketPath = debianFile.bucketPath.orNull ?: bucketPath.get()
 
@@ -145,7 +150,7 @@ abstract class UploadPackage : DefaultTask() {
             val changelogs = debianFile.changelogs.orNull ?: changelogs.orNull
             val snapshots = debianFile.snapshots.orNull ?: snapshots.orNull
 
-            val s3Client = AwsS3Client(accessKey, secretKey, region, endpoint)
+            val s3Client = AwsS3Client(accessKey, secretKey, region, endpoint, usePathStyle)
             val debianPoolBucketKey = getPoolBucketKey(inputFile.name, components)
             val debianPackages = PackagesFactory.parseDebianFile(
                 inputFile, packageArchitectures, debianPoolBucketKey, packageName, packageVersion

--- a/src/main/kotlin/com/liftric/apt/tasks/UploadPackage.kt
+++ b/src/main/kotlin/com/liftric/apt/tasks/UploadPackage.kt
@@ -42,7 +42,7 @@ abstract class UploadPackage : DefaultTask() {
     @get:Optional
     abstract val override: Property<Boolean>
 
-    @get:Input
+    @get:InputFile
     @get:Optional
     abstract val signingKeyRingFile: RegularFileProperty
 


### PR DESCRIPTION
- Updated Gradle to 8.9
- Updated Dependencies to latest Version
- Update Gradle Build Action to v2.4.2 to prevent secret leakage
- Fixed task property annotations for Gradle 8 compatibility
- Added usePathStyle option for S3 operations to support S3-compatible storage systems (>2.18.0 [aws sdk s3](https://github.com/aws/aws-sdk-java-v2/blob/2be163a018b15515125a0ca20cf011de26e5fa73/CHANGELOG.md#aws-sdk-for-java-v2) broke our itests with minio)
- Updated integration tests to force path-style S3 access
- Updated README with usePathStyle documentation
